### PR TITLE
Use files field instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-*~
-*.swp
-node_modules/
-.git
-tests/results
-.coveralls.yml

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Abstract streams to deal with the whole buffered contents.",
   "homepage": "https://github.com/nfroidure/BufferStreams",
   "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "test": "mocha tests/*.mocha.js",
     "coveralls": "istanbul cover _mocha --report lcovonly -- tests/*.mocha.js -t 5000 && istanbul-coveralls",


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json

> ### files
>
> The "files" field is an array of files to include in your project. If you name a folder in the array, then it will also include the files inside that folder. (Unless they would be ignored by another rule.)
>
> You can also provide a ".npmignore" file in the root of your package, which will keep files from being included, even if they would be picked up by the files array. The ".npmignore" file works just like a ".gitignore".

`README.md`, `LICENCE` and `package.json` are included by default. I think `files` is clearer than `.npmignore`.
